### PR TITLE
feat: externalize theme variables

### DIFF
--- a/themes/aurora/assets/css/buttons.css
+++ b/themes/aurora/assets/css/buttons.css
@@ -12,7 +12,7 @@ a.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 18px;
+  padding: var(--button-padding-large, 8px 18px);
   text-decoration: none;
   text-align: center;
   font: inherit;
@@ -27,7 +27,7 @@ button.outline,
 a.button.outline {
   background: transparent;
   box-shadow: none;
-  padding: 8px 18px;
+  padding: var(--button-padding-large, 8px 18px);
 }
 
 button.outline :hover,
@@ -53,8 +53,8 @@ a.button.small {
 button.wide,
 .button.wide,
 a.button.wide {
-  min-width: 200px;
-  padding: 14px 24px;
+  min-width: var(--button-min-width, 200px);
+  padding: var(--button-padding-wide, 14px 24px);
 }
 
 a.button.inline {

--- a/themes/aurora/assets/css/footer.css
+++ b/themes/aurora/assets/css/footer.css
@@ -1,9 +1,9 @@
 /* Footer layout and positioning */
 .footer {
-  padding: 40px 0;
+  padding: var(--footer-padding, 40px) 0;
   flex-grow: 0;
   margin-top: auto;
-  opacity: .55;
+  opacity: var(--footer-opacity, .55);
 }
 
 .footer__inner {

--- a/themes/aurora/assets/css/header.css
+++ b/themes/aurora/assets/css/header.css
@@ -60,7 +60,7 @@
   background: var(--accent);
   color: var(--background);
   font-weight: bold;
-  padding: 5px 10px;
+  padding: var(--logo-padding, 5px 10px);
 }
 
 @media print {
@@ -70,7 +70,7 @@
 }
 
 
-.header { padding-top: 6px; }
-.header__inner { margin-bottom: 10px; }
+.header { padding-top: var(--header-padding-top, 6px); }
+.header__inner { margin-bottom: var(--header-inner-margin-bottom, 10px); }
 
-.logo { border-radius: 8px; }
+.logo { border-radius: var(--logo-border-radius, 8px); }

--- a/themes/aurora/assets/css/main.css
+++ b/themes/aurora/assets/css/main.css
@@ -1,10 +1,4 @@
 /* Base structural styles */
-:root {
-  --font-size: clamp(1rem, 1vw + 0.5rem, 1.25rem);
-  --line-height: 1.54em;
-  --radius: 0;
-}
-
 html {
   box-sizing: border-box;
 }
@@ -27,8 +21,8 @@ html {
 }
 
 body {
-  margin: 0;
-  padding: 0;
+  margin: var(--body-margin, 0);
+  padding: var(--body-padding, 0);
   font-family: "Fira Code", Monaco, Consolas, "Ubuntu Mono", monospace;
   font-size: var(--font-size);
   line-height: var(--line-height);
@@ -75,7 +69,7 @@ img,
 figure,
 video,
 table {
-  margin: 25px 0;
+  margin: var(--block-margin, 25px) 0;
 }
 
 a {
@@ -90,8 +84,8 @@ button {
   text-align: center;
   background: transparent;
   color: var(--accent);
-  padding: 5px 18px;
-  border: 4px solid var(--accent);
+  padding: var(--button-padding, 5px 18px);
+  border: var(--button-border-width, 4px) solid var(--accent);
   border-radius: var(--radius);
   transition: background 0.15s linear;
   appearance: none;
@@ -450,7 +444,7 @@ blockquote.twitter-tweet::before {
 .container {
   display: flex;
   flex-direction: column;
-  padding: 40px;
+  padding: var(--container-padding, 40px);
   max-width: var(--container-max-width);
   min-height: 100vh;
   border-right: 1px solid color-mix(in srgb, var(--accent) 10%, transparent);
@@ -509,11 +503,11 @@ iframe[src*="youtube.com"] {
 
 @media (max-width: 684px) {
   :root {
-    --font-size: 0.95rem;
+    --font-size: var(--font-size-mobile, 0.95rem);
   }
 
   .container {
-    padding: 20px;
+    padding: var(--container-padding-mobile, 20px);
   }
 }
 

--- a/themes/aurora/assets/css/post.css
+++ b/themes/aurora/assets/css/post.css
@@ -1,11 +1,11 @@
 /* Post content and typography */
 .index-content {
-  margin: 25px 0;
+  margin: var(--block-margin, 25px) 0;
 }
 
 .framed {
   border: 1px solid var(--accent);
-  padding: 20px;
+  padding: var(--post-padding, 20px);
 }
 
 .framed *:first-child {
@@ -23,7 +23,7 @@
 .post {
   width: 100%;
   text-align: left;
-  padding: 30px 0;
+  padding: var(--post-meta-padding, 30px 0);
 }
 
 .post:not(:last-of-type) {
@@ -77,11 +77,11 @@
 }
 
 .post-content {
-  margin-top: 25px;
+  margin-top: var(--block-margin, 25px);
 }
 
 .post-cover {
-  margin: 25px 0;
+  margin: var(--block-margin, 25px) 0;
 }
 
 .post ul {

--- a/themes/aurora/assets/css/style.css
+++ b/themes/aurora/assets/css/style.css
@@ -1,11 +1,6 @@
 /* Theme tokens */
 /* Theme variables */
 :root {
-  --background: #f7f7eb;
-  --foreground: #000000;
-  --accent: #000000;
-  --container-max-width: 1200px;
-  --content-max-width: 90ch;
   --code-border: color-mix(in srgb, var(--foreground) 15%, transparent);
   --pagefind-ui-font: inherit;
   --pagefind-ui-primary: var(--accent);
@@ -20,9 +15,9 @@
 /* Dark theme overrides */
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #1a170f;
-    --foreground: #eceae5;
-    --accent: #eceae5;
+    --background: var(--dark-background, #1a170f);
+    --foreground: var(--dark-foreground, #eceae5);
+    --accent: var(--dark-accent, #eceae5);
     --code-border: color-mix(in srgb, var(--foreground) 15%, transparent);
   }
 }
@@ -355,15 +350,15 @@ kbd {
 
 /* Manual theme override */
 html[data-theme="light"] {
-  --background: #f7f7eb;
-  --foreground: #000000;
-  --accent:     #000000;
+  --background: var(--background);
+  --foreground: var(--foreground);
+  --accent:     var(--accent);
   --code-border: color-mix(in srgb, var(--foreground) 15%, transparent);
 }
 html[data-theme="dark"] {
-  --background: #1a170f;
-  --foreground: #eceae5;
-  --accent:     #eceae5;
+  --background: var(--dark-background, #1a170f);
+  --foreground: var(--dark-foreground, #eceae5);
+  --accent:     var(--dark-accent, #eceae5);
   --code-border: color-mix(in srgb, var(--foreground) 15%, transparent);
 }
 

--- a/themes/aurora/config.yml
+++ b/themes/aurora/config.yml
@@ -1,0 +1,53 @@
+# Aurora Theme Style Configuration
+# Update the values below to customize common theme dimensions and colors.
+# Provide valid CSS values (including units) for each option.
+#
+# Colors
+background: "#f7f7eb"        # Background color of the site
+foreground: "#000000"        # Default text color
+accent: "#000000"            # Accent color for links and interactive elements
+dark_background: "#1a170f"   # Background when dark theme is active
+dark_foreground: "#eceae5"   # Text color in dark theme
+dark_accent: "#eceae5"       # Accent color in dark theme
+
+# Layout widths
+container_max_width: "1200px" # Maximum width of the main container
+content_max_width: "90ch"     # Maximum width for readable content
+
+# Layout spacing
+container_padding: "40px"       # Padding inside the main container
+container_padding_mobile: "20px" # Container padding on small screens
+block_margin: "25px"           # Vertical spacing for block elements
+
+# Typography
+font_size: "clamp(1rem, 1vw + 0.5rem, 1.25rem)" # Base font size for body text
+font_size_mobile: "0.95rem"    # Base font size on small screens
+line_height: "1.54em"       # Line height for body text
+
+# Global spacing
+body_margin: "0"            # Margin around the body element
+body_padding: "0"           # Padding inside the body element
+
+# Shape
+radius: "0"                 # Border radius used across components
+
+# Header
+header_padding_top: "6px"          # Space above the site header
+header_inner_margin_bottom: "10px" # Space below the header's inner container
+logo_border_radius: "8px"          # Corner roundness of the logo box
+logo_padding: "5px 10px"           # Padding inside the logo box
+
+# Button
+button_padding: "5px 18px"         # Padding for <button> elements
+button_border_width: "4px"         # Border width for <button> elements
+button_padding_large: "8px 18px"   # Padding for .button elements
+button_padding_wide: "14px 24px"   # Padding for wide buttons
+button_min_width: "200px"          # Minimum width for wide buttons
+
+# Post
+post_padding: "20px"          # Padding inside post containers
+post_meta_padding: "30px 0"   # Padding around post metadata
+
+# Footer
+footer_padding: "40px"       # Vertical padding for the footer
+footer_opacity: "0.55"      # Opacity of the footer content

--- a/themes/aurora/layouts/partials/head.html
+++ b/themes/aurora/layouts/partials/head.html
@@ -20,6 +20,7 @@
 {{ if (fileExists "static/theme.css") }}<link rel="stylesheet" href="{{ "theme.css" | absURL }}">{{ end }}
 {{ if (fileExists "static/style.css") }}<link rel="stylesheet" href="{{ "style.css" | absURL }}">{{ end }}
 
+{{ partial "theme-config.html" . }}
 {{/* Icons */}}
 <link rel="shortcut icon" href="{{ "favicon.png" | absURL }}">
 <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | absURL }}">

--- a/themes/aurora/layouts/partials/theme-config.html
+++ b/themes/aurora/layouts/partials/theme-config.html
@@ -1,0 +1,8 @@
+{{- $cfg := readFile "themes/aurora/config.yml" | transform.Unmarshal -}}
+<style>
+:root {
+{{- range $key, $value := $cfg }}
+  --{{ replace $key "_" "-" }}: {{ $value }};
+{{- end }}
+}
+</style>


### PR DESCRIPTION
## Summary
- extend aurora config to cover dark theme colors, mobile typography, spacing, and component styling
- apply new CSS variables for block margins, container padding, button sizing, post spacing, and theme overrides

## Testing
- `apt-get update` *(fails: repository not signed)*
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae559fc33c8329919f127a7e29b6e3